### PR TITLE
altera a versão do pyjwt de 2.0.1 p/ 2.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,4 +26,4 @@ include_package_data = true
 packages = find:
 python_requires = >=3.6
 install_requires =
-    pyjwt==2.0.1
+    pyjwt==2.4.0


### PR DESCRIPTION
- No portal o pipeline está quebrando o step de safety devido a lib `pyjwt`. 
- Alterado a versão do pyjwt para 2.4.0.
